### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,11 +2,11 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-   # @items = Item.all
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new
-      @item = Item.new
+    @item = Item.new
   end
 
   def create

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
             <%= "#{item.product}" %>
           </h3>
           <div class='item-price'>
-            <span><%= "#{item.price}" %>円<br><%= "#{item.delivery_fee_id}" %></span>
+            <span><%= "#{item.price}" %>円<br><%= "#{item.delivery_fee.name}" %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,25 +127,26 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @items.present? %>
+    <% if @items.present? %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+         <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= "#{item.product}" %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= "#{item.price}" %>円<br><%= "#{item.delivery_fee_id}" %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +154,7 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 


### PR DESCRIPTION
# What
商品一覧機能実装できました
※『sold out』の表示は商品購入機能実装後に行います。

# Why
・商品がない場合はダミーが表示される。
https://gyazo.com/7360d5edfe97870f935bcecdf3e6b3c4
・出品された日時が新しい順に表示される。
https://gyazo.com/94728f3874fe8929e570014823ab3df6
・ロウグアウト状態でも一覧表示される。
https://gyazo.com/9a36d4ebbb602d73bf30bae5bde18e34

